### PR TITLE
fix: misconfigured sg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ resource "aws_autoscaling_group" "terramino" {
   launch_configuration = aws_launch_configuration.terramino.name
   vpc_zone_identifier  = module.vpc.public_subnets
 
+  health_check_type    = "ELB"
+
   tag {
     key                 = "Name"
     value               = "HashiCorp Learn ASG - Terramino"
@@ -107,7 +109,7 @@ resource "aws_security_group" "terramino_instance" {
     from_port       = 0
     to_port         = 0
     protocol        = "-1"
-    security_groups = [aws_security_group.terramino_lb.id]
+    cidr_blocks     = ["0.0.0.0/0"]
   }
 
   vpc_id = module.vpc.vpc_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "lb_endpoint" {
-  value = "https://${aws_lb.terramino.dns_name}"
+  value = "http://${aws_lb.terramino.dns_name}"
 }
 
 output "application_endpoint" {
-  value = "https://${aws_lb.terramino.dns_name}/index.php"
+  value = "http://${aws_lb.terramino.dns_name}/index.php"
 }
 
 output "asg_name" {


### PR DESCRIPTION
1. Egress should allow all.
https://developer.hashicorp.com/terraform/tutorials/aws/aws-asg#security-groups
_Both of these security groups allow ingress HTTP traffic on port 80 and all outbound traffic._

1. Listener on port 80, outputs shouldn't contain https://

1. ELB health checks for elb + asg
