### PR TITLE
explicitly define order of creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,7 @@ resource "aws_lb_target_group" "terramino" {
 
 
 resource "aws_autoscaling_attachment" "terramino" {
+  depends_on             = [aws_autoscaling_group.terramino, aws_lb_target_group.terramino]
   autoscaling_group_name = aws_autoscaling_group.terramino.id
   alb_target_group_arn   = aws_lb_target_group.terramino.arn
 }


### PR DESCRIPTION
Terraform resources are usually created in a dependency-resolved manner. However, in this case if we have to set the desired count as 2, then the ALB is throwing a 503 as target groups does not getting registered in time. 

I had to explicitly define dependencies using depends_on in your aws_autoscaling_attachment resource.